### PR TITLE
Rousselk@netopt cca threshold

### DIFF
--- a/drivers/kw2xrf/kw2xrf.c
+++ b/drivers/kw2xrf/kw2xrf.c
@@ -514,6 +514,25 @@ uint64_t kw2xrf_get_addr_long(kw2xrf_t *dev)
     return addr;
 }
 
+int8_t kw2xrf_get_cca_threshold(kw2xrf_t *dev)
+{
+    uint8_t tmp;
+    kw2xrf_read_iregs(MKW2XDMI_CCA1_THRESH, &tmp, 1);
+    /* KW2x register value represents absolute value in dBm
+     * default value: -75 dBm
+     */
+    return (-tmp);
+}
+
+void kw2xrf_set_cca_threshold(kw2xrf_t *dev, int8_t value)
+{
+    /* normalize to absolute value */
+    if (value < 0) {
+        value = -value;
+    }
+    kw2xrf_write_iregs(MKW2XDMI_CCA1_THRESH, (uint8_t*)&value, 1);
+}
+
 int kw2xrf_get(gnrc_netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
 {
     kw2xrf_t *dev = (kw2xrf_t *)netdev;
@@ -603,6 +622,14 @@ int kw2xrf_get(gnrc_netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
             }
 
             *(int16_t *)value = dev->tx_power;
+            return 0;
+
+        case NETOPT_CCA_THRESHOLD:
+            if (max_len < sizeof(uint8_t)) {
+                return -EOVERFLOW;
+            } else {
+            *(int8_t *)value = kw2xrf_get_cca_threshold(dev);
+            }
             return 0;
 
         case NETOPT_MAX_PACKET_SIZE:
@@ -775,6 +802,14 @@ int kw2xrf_set(gnrc_netdev_t *netdev, netopt_t opt, void *value, size_t value_le
 
             kw2xrf_set_tx_power(dev, (int8_t *)value, value_len);
             return sizeof(uint16_t);
+        
+        case NETOPT_CCA_THRESHOLD:
+            if (value_len < sizeof(uint8_t)) {
+                return -EOVERFLOW;
+            } else {
+                kw2xrf_set_cca_threshold(dev, *((int8_t*)value));
+            }
+            return sizeof(uint8_t);
 
         case NETOPT_PROTO:
             return kw2xrf_set_proto(dev, (uint8_t *)value, value_len);

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -82,6 +82,7 @@ static void _set_usage(char *cmd_name)
          "       * \"channel\" - sets the frequency channel\n"
          "       * \"chan\" - alias for \"channel\"\n"
          "       * \"csma_retries\" - set max. number of channel access attempts\n"
+         "       * \"cca_threshold\" - set ED threshold during CCA in dBm\n"
          "       * \"nid\" - sets the network identifier (or the PAN ID)\n"
          "       * \"pan\" - alias for \"nid\"\n"
          "       * \"pan_id\" - alias for \"nid\"\n"
@@ -97,7 +98,7 @@ static void _mtu_usage(char *cmd_name)
 
 static void _flag_usage(char *cmd_name)
 {
-    printf("usage: %s <if_id> [-]{promisc|autoack|csma|autocca|preload|iphc}\n", cmd_name);
+    printf("usage: %s <if_id> [-]{promisc|autoack|csma|autocca|cca_threshold|preload|iphc}\n", cmd_name);
 }
 
 static void _add_usage(char *cmd_name)
@@ -143,6 +144,10 @@ static void _print_netopt(netopt_t opt)
             printf("CSMA retries");
             break;
 
+        case NETOPT_CCA_THRESHOLD:
+            printf("CCA threshold [in dBm]");
+            break;
+        
         default:
             /* we don't serve these options here */
             break;
@@ -556,6 +561,9 @@ static int _netif_set(char *cmd_name, kernel_pid_t dev, char *key, char *value)
     }
     else if (strcmp("csma_retries", key) == 0) {
         return _netif_set_u8(dev, NETOPT_CSMA_RETRIES, value);
+    }
+    else if (strcmp("cca_threshold", key) == 0) {
+        return _netif_set_u8(dev, NETOPT_CCA_THRESHOLD, value);
     }
 
     _set_usage(cmd_name);


### PR DESCRIPTION
1. Adds netopt_cca_threshold settings to kw2xrf-device.
2. Adds testing entries to shell (Not sure if we need that, I used it primarily for testing).
